### PR TITLE
DB Migration for user.reference_id 

### DIFF
--- a/infra/hasura/migrations/default/1664266120649_alter_table_public_users_alter_column_reference_id/down.sql
+++ b/infra/hasura/migrations/default/1664266120649_alter_table_public_users_alter_column_reference_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "reference_id" set default "substring"(md5((random())::text), 0, 9);

--- a/infra/hasura/migrations/default/1664266120649_alter_table_public_users_alter_column_reference_id/up.sql
+++ b/infra/hasura/migrations/default/1664266120649_alter_table_public_users_alter_column_reference_id/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "reference_id" set default "substring"(md5((random())::text), 0, 9);


### PR DESCRIPTION
This PR holds a db migration only.
user.reference_id  is set as 8 char alphanumeric.