### PR TITLE
Convert text type to custom enum type in Db

### DIFF
--- a/infra/hasura/migrations/default/1683786871863_convert text type to match_type_enum for match_type column in allowed_emails table/down.sql
+++ b/infra/hasura/migrations/default/1683786871863_convert text type to match_type_enum for match_type column in allowed_emails table/down.sql
@@ -1,0 +1,9 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE match_type_enum AS ENUM ('EMAIL', 'DOMAIN');
+-- ALTER TABLE allowed_emails
+--   ALTER COLUMN match_type DROP DEFAULT,
+--   ALTER COLUMN match_type
+--     SET DATA TYPE match_type_enum
+--     USING match_type::text::match_type_enum,
+--   ALTER COLUMN match_type SET DEFAULT 'EMAIL';

--- a/infra/hasura/migrations/default/1683786871863_convert text type to match_type_enum for match_type column in allowed_emails table/up.sql
+++ b/infra/hasura/migrations/default/1683786871863_convert text type to match_type_enum for match_type column in allowed_emails table/up.sql
@@ -1,0 +1,7 @@
+CREATE TYPE match_type_enum AS ENUM ('EMAIL', 'DOMAIN');
+ALTER TABLE allowed_emails
+  ALTER COLUMN match_type DROP DEFAULT,
+  ALTER COLUMN match_type
+    SET DATA TYPE match_type_enum
+    USING match_type::text::match_type_enum,
+  ALTER COLUMN match_type SET DEFAULT 'EMAIL';

--- a/infra/hasura/migrations/default/1683787345817_convert text type to match_type_enum for match_type column in disabled_emails table/down.sql
+++ b/infra/hasura/migrations/default/1683787345817_convert text type to match_type_enum for match_type column in disabled_emails table/down.sql
@@ -1,0 +1,6 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- ALTER TABLE disabled_emails
+--   ALTER COLUMN match_type
+--     SET DATA TYPE match_type_enum
+--     USING match_type::text::match_type_enum;

--- a/infra/hasura/migrations/default/1683787345817_convert text type to match_type_enum for match_type column in disabled_emails table/up.sql
+++ b/infra/hasura/migrations/default/1683787345817_convert text type to match_type_enum for match_type column in disabled_emails table/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE disabled_emails
+  ALTER COLUMN match_type
+    SET DATA TYPE match_type_enum
+    USING match_type::text::match_type_enum;

--- a/infra/hasura/migrations/default/1683787710005_convert text type to status_type1_enum for status column in billing_org table/down.sql
+++ b/infra/hasura/migrations/default/1683787710005_convert text type to status_type1_enum for status column in billing_org table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE status_type1_enum AS ENUM ('inactive', 'active');
+-- ALTER TABLE billing_org
+--   ALTER COLUMN status
+--     SET DATA TYPE status_type1_enum
+--     USING status::text::status_type1_enum;

--- a/infra/hasura/migrations/default/1683787710005_convert text type to status_type1_enum for status column in billing_org table/up.sql
+++ b/infra/hasura/migrations/default/1683787710005_convert text type to status_type1_enum for status column in billing_org table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE status_type1_enum AS ENUM ('inactive', 'active');
+ALTER TABLE billing_org
+  ALTER COLUMN status
+    SET DATA TYPE status_type1_enum
+    USING status::text::status_type1_enum;

--- a/infra/hasura/migrations/default/1683788975535_convert text type to resource_type_enum for resource column in data_discard table/down.sql
+++ b/infra/hasura/migrations/default/1683788975535_convert text type to resource_type_enum for resource column in data_discard table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE resource_type_enum AS ENUM ( 'companies', 'vc_firms', 'people', 'blockchains', 'coins', 'investment_rounds', 'investments', 'team_members', 'investors', 'events', 'event_person', 'event_organization', 'resource_links', 'news', 'news_organizations', 'news_person');
+-- ALTER TABLE data_discard
+--   ALTER COLUMN resource
+--     SET DATA TYPE resource_type_enum
+--     USING resource::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683788975535_convert text type to resource_type_enum for resource column in data_discard table/up.sql
+++ b/infra/hasura/migrations/default/1683788975535_convert text type to resource_type_enum for resource column in data_discard table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE resource_type_enum AS ENUM ( 'companies', 'vc_firms', 'people', 'blockchains', 'coins', 'investment_rounds', 'investments', 'team_members', 'investors', 'events', 'event_person', 'event_organization', 'resource_links', 'news', 'news_organizations', 'news_person');
+ALTER TABLE data_discard
+  ALTER COLUMN resource
+    SET DATA TYPE resource_type_enum
+    USING resource::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683789289330_convert text type to resource_type1_enum for resource column in data_fields table/down.sql
+++ b/infra/hasura/migrations/default/1683789289330_convert text type to resource_type1_enum for resource column in data_fields table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE resource_type1_enum AS ENUM ( 'company', 'vc_firm', 'people', 'blockchain', 'coin', 'investment_round', 'investment', 'team_member', 'investor', 'event', 'event_person', 'event_organization', 'resource_link', 'news', 'news_organization', 'news_person');
+-- ALTER TABLE data_fields
+--   ALTER COLUMN resource
+--     SET DATA TYPE resource_type1_enum
+--     USING resource::text::resource_type1_enum;

--- a/infra/hasura/migrations/default/1683789289330_convert text type to resource_type1_enum for resource column in data_fields table/up.sql
+++ b/infra/hasura/migrations/default/1683789289330_convert text type to resource_type1_enum for resource column in data_fields table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE resource_type1_enum AS ENUM ( 'company', 'vc_firm', 'people', 'blockchain', 'coin', 'investment_round', 'investment', 'team_member', 'investor', 'event', 'event_person', 'event_organization', 'resource_link', 'news', 'news_organization', 'news_person');
+ALTER TABLE data_fields
+  ALTER COLUMN resource
+    SET DATA TYPE resource_type1_enum
+    USING resource::text::resource_type1_enum;

--- a/infra/hasura/migrations/default/1683789407824_convert text type to resource_type_enum for resource column in data_raw table/down.sql
+++ b/infra/hasura/migrations/default/1683789407824_convert text type to resource_type_enum for resource column in data_raw table/down.sql
@@ -1,0 +1,6 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- ALTER TABLE data_raw
+--   ALTER COLUMN resource
+--     SET DATA TYPE resource_type_enum
+--     USING resource::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683789407824_convert text type to resource_type_enum for resource column in data_raw table/up.sql
+++ b/infra/hasura/migrations/default/1683789407824_convert text type to resource_type_enum for resource column in data_raw table/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE data_raw
+  ALTER COLUMN resource
+    SET DATA TYPE resource_type_enum
+    USING resource::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683789720176_convert text type to classification_type_enum for classification column in data_runs table/down.sql
+++ b/infra/hasura/migrations/default/1683789720176_convert text type to classification_type_enum for classification column in data_runs table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE classification_type_enum AS ENUM ('new', 'incorrect', 'validated');
+-- ALTER TABLE data_runs
+--   ALTER COLUMN classification
+--     SET DATA TYPE classification_type_enum
+--     USING classification::text::classification_type_enum;

--- a/infra/hasura/migrations/default/1683789720176_convert text type to classification_type_enum for classification column in data_runs table/up.sql
+++ b/infra/hasura/migrations/default/1683789720176_convert text type to classification_type_enum for classification column in data_runs table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE classification_type_enum AS ENUM ('new', 'incorrect', 'validated');
+ALTER TABLE data_runs
+  ALTER COLUMN classification
+    SET DATA TYPE classification_type_enum
+    USING classification::text::classification_type_enum;

--- a/infra/hasura/migrations/default/1683790081021_convert text type to event_organization_type_enum for type column in event_organization table/down.sql
+++ b/infra/hasura/migrations/default/1683790081021_convert text type to event_organization_type_enum for type column in event_organization table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE event_organization_type_enum AS ENUM ('sponsor', 'organizer');
+-- ALTER TABLE event_organization
+--   ALTER COLUMN "type"
+--     SET DATA TYPE event_organization_type_enum
+--     USING "type"::text::event_organization_type_enum;

--- a/infra/hasura/migrations/default/1683790081021_convert text type to event_organization_type_enum for type column in event_organization table/up.sql
+++ b/infra/hasura/migrations/default/1683790081021_convert text type to event_organization_type_enum for type column in event_organization table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE event_organization_type_enum AS ENUM ('sponsor', 'organizer');
+ALTER TABLE event_organization
+  ALTER COLUMN "type"
+    SET DATA TYPE event_organization_type_enum
+    USING "type"::text::event_organization_type_enum;

--- a/infra/hasura/migrations/default/1683790242622_convert text type to event_person_type_enum for type column in event_person table/down.sql
+++ b/infra/hasura/migrations/default/1683790242622_convert text type to event_person_type_enum for type column in event_person table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE event_person_type_enum AS ENUM ('speaker', 'attendee', 'organizer');
+-- ALTER TABLE event_person
+--   ALTER COLUMN "type"
+--     SET DATA TYPE event_person_type_enum
+--     USING "type"::text::event_person_type_enum;

--- a/infra/hasura/migrations/default/1683790242622_convert text type to event_person_type_enum for type column in event_person table/up.sql
+++ b/infra/hasura/migrations/default/1683790242622_convert text type to event_person_type_enum for type column in event_person table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE event_person_type_enum AS ENUM ('speaker', 'attendee', 'organizer');
+ALTER TABLE event_person
+  ALTER COLUMN "type"
+    SET DATA TYPE event_person_type_enum
+    USING "type"::text::event_person_type_enum;

--- a/infra/hasura/migrations/default/1683791694018_convert text type to member_type_enum for member_type column in list_members table/down.sql
+++ b/infra/hasura/migrations/default/1683791694018_convert text type to member_type_enum for member_type column in list_members table/down.sql
@@ -1,0 +1,9 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE member_type_enum AS ENUM ('follow', 'owner');
+-- ALTER TABLE list_members
+--   ALTER COLUMN member_type DROP DEFAULT,
+--   ALTER COLUMN member_type
+--     SET DATA TYPE member_type_enum
+--     USING member_type::text::member_type_enum,
+--   ALTER COLUMN member_type SET DEFAULT 'follow';

--- a/infra/hasura/migrations/default/1683791694018_convert text type to member_type_enum for member_type column in list_members table/up.sql
+++ b/infra/hasura/migrations/default/1683791694018_convert text type to member_type_enum for member_type column in list_members table/up.sql
@@ -1,0 +1,7 @@
+CREATE TYPE member_type_enum AS ENUM ('follow', 'owner');
+ALTER TABLE list_members
+  ALTER COLUMN member_type DROP DEFAULT,
+  ALTER COLUMN member_type
+    SET DATA TYPE member_type_enum
+    USING member_type::text::member_type_enum,
+  ALTER COLUMN member_type SET DEFAULT 'follow';

--- a/infra/hasura/migrations/default/1683791894478_convert text type to kind_type_enum for kind column in news table/down.sql
+++ b/infra/hasura/migrations/default/1683791894478_convert text type to kind_type_enum for kind column in news table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE kind_type_enum AS ENUM ('news', 'media');
+-- ALTER TABLE news
+--   ALTER COLUMN kind
+--     SET DATA TYPE kind_type_enum
+--     USING kind::text::kind_type_enum;

--- a/infra/hasura/migrations/default/1683791894478_convert text type to kind_type_enum for kind column in news table/up.sql
+++ b/infra/hasura/migrations/default/1683791894478_convert text type to kind_type_enum for kind column in news table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE kind_type_enum AS ENUM ('news', 'media');
+ALTER TABLE news
+  ALTER COLUMN kind
+    SET DATA TYPE kind_type_enum
+    USING kind::text::kind_type_enum;

--- a/infra/hasura/migrations/default/1683792219151_convert text type to news_organizations_type_enum for type column in news_organizations table/down.sql
+++ b/infra/hasura/migrations/default/1683792219151_convert text type to news_organizations_type_enum for type column in news_organizations table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE news_organizations_type_enum AS ENUM ('publisher', 'subject');
+-- ALTER TABLE news_organizations
+--   ALTER COLUMN "type"
+--     SET DATA TYPE news_organizations_type_enum
+--     USING "type"::text::news_organizations_type_enum;

--- a/infra/hasura/migrations/default/1683792219151_convert text type to news_organizations_type_enum for type column in news_organizations table/up.sql
+++ b/infra/hasura/migrations/default/1683792219151_convert text type to news_organizations_type_enum for type column in news_organizations table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE news_organizations_type_enum AS ENUM ('publisher', 'subject');
+ALTER TABLE news_organizations
+  ALTER COLUMN "type"
+    SET DATA TYPE news_organizations_type_enum
+    USING "type"::text::news_organizations_type_enum;

--- a/infra/hasura/migrations/default/1683792482790_convert text type to resource_type_enum for resource_type column in notes table/down.sql
+++ b/infra/hasura/migrations/default/1683792482790_convert text type to resource_type_enum for resource_type column in notes table/down.sql
@@ -1,0 +1,6 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- ALTER TABLE notes
+--   ALTER COLUMN resource_type
+--     SET DATA TYPE resource_type_enum
+--     USING resource_type::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683792482790_convert text type to resource_type_enum for resource_type column in notes table/up.sql
+++ b/infra/hasura/migrations/default/1683792482790_convert text type to resource_type_enum for resource_type column in notes table/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE notes
+  ALTER COLUMN resource_type
+    SET DATA TYPE resource_type_enum
+    USING resource_type::text::resource_type_enum;

--- a/infra/hasura/migrations/default/1683792784915_convert text type to event_type_enum for event_type column in notifications table/down.sql
+++ b/infra/hasura/migrations/default/1683792784915_convert text type to event_type_enum for event_type column in notifications table/down.sql
@@ -1,0 +1,7 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE TYPE event_type_enum AS ENUM ('Change Data', 'Insert Data', 'Delete Data');
+-- ALTER TABLE notifications
+--   ALTER COLUMN event_type
+--     SET DATA TYPE event_type_enum
+--     USING event_type::text::event_type_enum;

--- a/infra/hasura/migrations/default/1683792784915_convert text type to event_type_enum for event_type column in notifications table/up.sql
+++ b/infra/hasura/migrations/default/1683792784915_convert text type to event_type_enum for event_type column in notifications table/up.sql
@@ -1,0 +1,5 @@
+CREATE TYPE event_type_enum AS ENUM ('Change Data', 'Insert Data', 'Delete Data');
+ALTER TABLE notifications
+  ALTER COLUMN event_type
+    SET DATA TYPE event_type_enum
+    USING event_type::text::event_type_enum;


### PR DESCRIPTION
Migration to convert text to custom enum types in db.
There are some fields that can not convert text type to custom type enum in Db because data includes null value or non-value and some fields require permission as below:
- status - companies table
- status - events table
- resource_type - follows table
- status - investment_rounds table
- status - investments table
- status - news table
- status - people table
