### PR TITLE
Fix paths for @ for scripts directory

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": "../",
+    "paths": {
+      "@/*": ["*"]
+    },
     "target": "es6",
     "module": "commonjs",
     "esModuleInterop": true


### PR DESCRIPTION
From https://github.com/5of5/edgein-next/pull/550, there's @ refer in utils/constants, which is referred in ts scripts in scripts/ dir