### PR TITLE
cloudsponge styles

### DIFF
--- a/styles/cloudsponge.scss
+++ b/styles/cloudsponge.scss
@@ -1,0 +1,47 @@
+/* Cloudsponge: replace appearance (Replace #0097A7 with tw primary-500) */
+#cloudsponge-root-holder {
+  #cloudsponge-address-book {
+    @apply bg-transparent;
+    a {
+      @apply text-primary-500;
+    }
+    .cloudsponge-topbar,
+    .cloudsponge-back-button,
+    .cloudsponge-close-button,
+    .cloudsponge-menu-button {
+      @apply text-gray-900 bg-gray-100 border-b border-gray-200;
+      .cloudsponge-h1 {
+        @apply font-medium;
+      }
+    }
+    .cloudsponge-header {
+      @apply bg-white;
+    }
+    .cloudsponge-widget {
+      @apply font-sans bg-white;
+    }
+    .cloudsponge-providers-list {
+      @apply my-6 mx-auto;
+      li a {
+        @apply font-normal rounded-lg border-solid text-gray-900 border border-gray-200 hover:bg-gray-50;
+      }
+    }
+    .cloudsponge-dictionary a {
+      @apply text-primary-500;
+    }
+    ul.cloudsponge-contacts-list > li {
+      input[type='checkbox']:checked + label::before {
+        @apply text-primary-500;
+      }
+      &.cloudsponge-selected .cloudsponge-row-container {
+        @apply bg-gray-100;
+      }
+    }
+    .cloudsponge-button.cloudsponge-export-button {
+      @apply bg-primary-500 text-white hover:bg-blue-900;
+    }
+    .cloudsponge-copyright {
+      @apply hidden;
+    }
+  }
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,3 +1,4 @@
+@use './cloudsponge';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -56,35 +57,6 @@
       transparent 6px,
       transparent 12px
     );
-  }
-}
-
-/* Cloudsponge: replace appearance */
-#cloudsponge-root-holder {
-  #cloudsponge-address-book {
-    @apply bg-transparent;
-
-    .cloudsponge-topbar,
-    .cloudsponge-back-button,
-    .cloudsponge-close-button,
-    .cloudsponge-menu-button {
-      @apply text-gray-900 bg-gray-100 border-b border-gray-200;
-      .cloudsponge-h1 {
-        @apply font-medium;
-      }
-    }
-    .cloudsponge-widget {
-      @apply font-sans bg-white;
-    }
-    .cloudsponge-providers-list {
-      @apply my-6 mx-auto;
-      li a {
-        @apply font-normal rounded-lg border-solid border border-gray-200 hover:bg-gray-50;
-      }
-    }
-    .cloudsponge-copyright {
-      @apply hidden;
-    }
   }
 }
 


### PR DESCRIPTION
Replaced ugly cloudsponge styles with current styles via tailwind classes and removed cloudsponge branding: 

<img width="859" alt="cloudsponge-styles" src="https://github.com/5of5/edgein-next/assets/2752967/c118fd4c-4b21-47b7-8f6f-d30a798b515f">
