### PR TITLE
Add email switch to account page

### DIFF
--- a/components/profile/profile-edit-daily-emails.tsx
+++ b/components/profile/profile-edit-daily-emails.tsx
@@ -37,8 +37,14 @@ export const ProfileEditDailyEmails: React.FC<Props> = ({ user }) => {
 
   return (
     <EditSection heading="Daily emails">
+       <p className="text-gray-600 text-sm">
+        Turn on or turn off emails with the latest personalised daily digest
+        about closed investments, trending companies, upcoming events in your
+        area or recent news.
+      </p>
       <InputSwitch
         label=""
+        className="mt-2 -ml-2"
         checked={dailyEmails}
         onChange={handleSwitchDailyEmails}
       />

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -20,6 +20,7 @@ import { ElemInviteInvestmentMembers } from '@/components/invites/elem-invite-in
 
 import validator from 'validator';
 import { isEmpty } from 'lodash';
+import { ProfileEditDailyEmails } from '@/components/profile/profile-edit-daily-emails';
 
 export default function Account() {
   const { user, refreshUser } = useAuth();
@@ -315,6 +316,12 @@ export default function Account() {
               )}
             </EditSection>
           )}
+
+          {
+            userProfile && (
+              <ProfileEditDailyEmails user={userProfile.users_by_pk} />
+            )
+          }
 
           <EditSection
             heading="Subscription"

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -29,7 +29,6 @@ import { usePopup } from '@/context/popup-context';
 // import { InputDate } from "@/components/InputDate";
 // import { GetStaticProps } from "next";
 import { EditSection } from '@/components/dashboard/edit-section';
-import { ProfileEditDailyEmails } from '@/components/profile/profile-edit-daily-emails';
 // import { functionChoicesTM } from "@/utils/constants";
 // import { ElemCompaniesSearchInput } from "@/components/Companies/ElemCompaniesSearchInput";
 
@@ -603,7 +602,6 @@ const Profile: FC<Props> = ({ companiesDropdown }) => {
         ) : (
           <>
             <ProfileEditName />
-            <ProfileEditDailyEmails user={users!.users_by_pk} />
             <ProfileEditEmail />
 
             {users?.users_by_pk?.person && (


### PR DESCRIPTION
The change was requested in the following [Notion doc](https://www.notion.so/edgeinio/d22ad9846aaa479eb8a26974fe4c1684?v=12645f32167b4406a24f413e976fd12c&p=a7a75c6d8abe4e919b36550294b9cf41&pm=c)

<img width="1262" alt="Screenshot 2023-08-28 at 16 29 59" src="https://github.com/5of5/edgein-next/assets/13850339/4d7f4851-f12f-49bc-a0b8-48790de9f746">
