### PR TITLE
add lists limit on save to list modal

### DIFF
--- a/components/elem-save-to-list.tsx
+++ b/components/elem-save-to-list.tsx
@@ -16,6 +16,7 @@ import { listSchema } from '@/utils/schema';
 import { zodValidate } from '@/utils/validation';
 import { find, isEqual } from 'lodash';
 import { useRouter } from 'next/router';
+import { FREE_USER_MAXIMUM_LISTS } from '@/utils/constants';
 import { ElemUpgradeDialog } from './elem-upgrade-dialog';
 
 type Props = {
@@ -259,7 +260,8 @@ export const ElemSaveToList: FC<Props> = ({
   };
 
   const onClickShowCreateNew = () => {
-    const userListsLimit = user?.entitlements.listsCount ?? 5;
+    const userListsLimit =
+      user?.entitlements.listsCount ?? FREE_USER_MAXIMUM_LISTS;
 
     if (listsData.length > userListsLimit) {
       onOpenUpgradeDialog();

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2003,6 +2003,8 @@ export const CARD_DEFAULT_TAGS_LIMIT = 3;
 
 export const CARD_MAX_TAGS_LIMIT = 50;
 
+export const FREE_USER_MAXIMUM_LISTS = 5;
+
 export const SIDEBAR_DEFAULT_LISTS_LIMIT = 3;
 
 export const SIDEBAR_DEFAULT_GROUPS_LIMIT = 3;


### PR DESCRIPTION
Limit lists for free users in "Save to list" modal, explained on issue #786: 
[Loom](https://www.loom.com/share/9eebd1cf26a640cf9b397bdf47928425?sid=f769b6d3-952e-403b-9abc-6a06bdb26497)