### PR TITLE
limit tags shown on company and investor profiles

### DIFF
--- a/pages/companies/[companyId].tsx
+++ b/pages/companies/[companyId].tsx
@@ -28,7 +28,10 @@ import {
   Order_By,
 } from '@/graphql/types';
 // import { ElemReactions } from '@/components/elem-reactions';
-import { tokenInfoMetrics } from '@/utils/constants';
+import {
+  COMPANY_PROFILE_DEFAULT_TAGS_LIMIT,
+  tokenInfoMetrics,
+} from '@/utils/constants';
 import { convertToInternationalCurrencySystem } from '@/utils';
 import { sortBy } from 'lodash';
 import parse from 'html-react-parser';
@@ -220,6 +223,7 @@ const Company: NextPage<Props> = (props: Props) => {
 
             <ElemTags
               className="mt-4"
+              limit={COMPANY_PROFILE_DEFAULT_TAGS_LIMIT}
               resourceType={'companies'}
               tags={company.tags}
             />

--- a/pages/investors/[investorId].tsx
+++ b/pages/investors/[investorId].tsx
@@ -32,6 +32,7 @@ import ElemOrganizationNotes from '@/components/elem-organization-notes';
 import ElemNewsList from '@/components/news/elem-news-list';
 import { useUser } from '@/context/user-context';
 import { DashboardLayout } from '@/components/dashboard/dashboard-layout';
+import { INVESTOR_PROFILE_DEFAULT_TAGS_LIMIT } from '@/utils/constants';
 
 type Props = {
   vcfirm: Vc_Firms;
@@ -141,6 +142,7 @@ const VCFirm: NextPage<Props> = props => {
             {vcfirm.tags?.length > 0 && (
               <ElemTags
                 className="mt-4"
+                limit={INVESTOR_PROFILE_DEFAULT_TAGS_LIMIT}
                 resourceType={'investors'}
                 tags={vcfirm.tags}
               />

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2015,6 +2015,10 @@ export const NEW_CATEGORY_LIMIT = 33;
 
 export const TRENDING_CATEGORY_LIMIT = 25;
 
+export const COMPANY_PROFILE_DEFAULT_TAGS_LIMIT = 5;
+
+export const INVESTOR_PROFILE_DEFAULT_TAGS_LIMIT = 5;
+
 export const segmentChoices: SegmentOption[] = [
   {
     title: 'Executive',


### PR DESCRIPTION
Limit amount of tags shown on profile to prevent broken UI.

**Before: too many tags shown** 
<img width="880" alt="too-many-tags" src="https://github.com/5of5/edgein-next/assets/2752967/ebc3426a-3fa1-4054-9bfa-fbdd70c5d194">

**After: only first tags are shown but all tags can be viewed if interested**
<img width="1445" alt="Screenshot 2023-09-19 at 5 44 19 PM" src="https://github.com/5of5/edgein-next/assets/2752967/9505a6df-9e09-4782-8969-ff5806182ed8">

