### PR TITLE
Global style fixes

### DIFF
--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -12,7 +12,8 @@ export const IconSpinner: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="none"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Loading'}</title>
       <circle
         className="opacity-25"
@@ -20,11 +21,13 @@ export const IconSpinner: FC<IconProps> = ({ className, title }) => {
         cy="12"
         r="10"
         stroke="currentColor"
-        strokeWidth="4"></circle>
+        strokeWidth="4"
+      ></circle>
       <path
         className="opacity-75 ring-4 ring-primary-500"
         fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
     </svg>
   );
 };
@@ -41,7 +44,8 @@ export const IconArrowRight: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Arrow Right'}</title>
       <path
         strokeLinecap="round"
@@ -64,7 +68,8 @@ export const IconArrowUp: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Arrow Up'}</title>
       <path
         strokeLinecap="round"
@@ -83,7 +88,8 @@ export const IconEye: FC<IconProps> = ({ className, strokeWidth, title }) => {
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'View'}</title>
       <path
         strokeLinecap="round"
@@ -111,7 +117,8 @@ export const IconEyeSlash: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Hide'}</title>
       <path
         strokeLinecap="round"
@@ -134,7 +141,8 @@ export const IconWindowSidebar: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Sidebar'}</title>
       <path
         d="M9.5 3.75H5.25C4.65326 3.75 4.08097 3.98705 3.65901 4.40901C3.23705 4.83097 3 5.40326 3 6V18C3 18.5967 3.23705 19.169 3.65901 19.591C4.08097 20.0129 4.65326 20.25 5.25 20.25H9.5M9.5 3.75H18.75C19.3467 3.75 19.919 3.98705 20.341 4.40901C20.7629 4.83097 21 5.40326 21 6V18C21 18.5967 20.7629 19.169 20.341 19.591C19.919 20.0129 19.3467 20.25 18.75 20.25H9.5M9.5 3.75V20.25M4.75 6H7.5M4.75 8.5H7.5M4.75 11H7.5"
@@ -157,7 +165,8 @@ export const IconArrowDown: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Arrow Down'}</title>
       <path
         strokeLinecap="round"
@@ -175,7 +184,8 @@ export const IconCurrencyDollar: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={2}>
+      strokeWidth={2}
+    >
       <title>{title ? title : 'Currency Dollar'}</title>
       <path
         d="M12 8C10.343 8 9 8.895 9 10C9 11.105 10.343 12 12 12C13.657 12 15 12.895 15 14C15 15.105 13.657 16 12 16V8ZM12 8C13.11 8 14.08 8.402 14.599 9L12 8ZM12 8V7V8ZM12 8V16V8ZM12 16V17V16ZM12 16C10.89 16 9.92 15.598 9.401 15L12 16ZM21 12C21 13.1819 20.7672 14.3522 20.3149 15.4442C19.8626 16.5361 19.1997 17.5282 18.364 18.364C17.5282 19.1997 16.5361 19.8626 15.4442 20.3149C14.3522 20.7672 13.1819 21 12 21C10.8181 21 9.64778 20.7672 8.55585 20.3149C7.46392 19.8626 6.47177 19.1997 5.63604 18.364C4.80031 17.5282 4.13738 16.5361 3.68508 15.4442C3.23279 14.3522 3 13.1819 3 12C3 9.61305 3.94821 7.32387 5.63604 5.63604C7.32387 3.94821 9.61305 3 12 3C14.3869 3 16.6761 3.94821 18.364 5.63604C20.0518 7.32387 21 9.61305 21 12Z"
@@ -213,7 +223,8 @@ export const IconInformationCircle: FC<IconProps> = ({
       className={className}
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Info'}</title>
       <path
         strokeLinecap="round"
@@ -230,7 +241,8 @@ export const IconChartUp: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 20 20"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Chart Up'}</title>
       <path d="M2 12.9053C2 12.6819 2.08872 12.4677 2.24665 12.3098C2.40457 12.1519 2.61877 12.0632 2.84211 12.0632H4.52632C4.74966 12.0632 4.96385 12.1519 5.12177 12.3098C5.2797 12.4677 5.36842 12.6819 5.36842 12.9053V17.1158C5.36842 17.3391 5.2797 17.5533 5.12177 17.7112C4.96385 17.8692 4.74966 17.9579 4.52632 17.9579H2.84211C2.61877 17.9579 2.40457 17.8692 2.24665 17.7112C2.08872 17.5533 2 17.3391 2 17.1158V12.9053ZM6.21053 9.53684C6.21053 9.3135 6.29925 9.09931 6.45717 8.94138C6.6151 8.78346 6.82929 8.69474 7.05263 8.69474H8.73684C8.96018 8.69474 9.17438 8.78346 9.3323 8.94138C9.49023 9.09931 9.57895 9.3135 9.57895 9.53684V17.1158C9.57895 17.3391 9.49023 17.5533 9.3323 17.7112C9.17438 17.8692 8.96018 17.9579 8.73684 17.9579H7.05263C6.82929 17.9579 6.6151 17.8692 6.45717 17.7112C6.29925 17.5533 6.21053 17.3391 6.21053 17.1158V9.53684ZM10.4211 11.2211C10.4211 10.9977 10.5098 10.7835 10.6677 10.6256C10.8256 10.4677 11.0398 10.3789 11.2632 10.3789H12.9474C13.1707 10.3789 13.3849 10.4677 13.5428 10.6256C13.7008 10.7835 13.7895 10.9977 13.7895 11.2211V17.1158C13.7895 17.3391 13.7008 17.5533 13.5428 17.7112C13.3849 17.8692 13.1707 17.9579 12.9474 17.9579H11.2632C11.0398 17.9579 10.8256 17.8692 10.6677 17.7112C10.5098 17.5533 10.4211 17.3391 10.4211 17.1158V11.2211Z" />
       <path d="M14.8782 7.25717C14.7203 7.4151 14.6316 7.62929 14.6316 7.85263V17.1158C14.6316 17.3391 14.7203 17.5533 14.8782 17.7112C15.0362 17.8692 15.2503 17.9579 15.4737 17.9579H17.1579C17.3812 17.9579 17.5954 17.8692 17.7534 17.7112C17.9113 17.5533 18 17.3391 18 17.1158V7.85263C18 7.62929 17.9113 7.4151 17.7534 7.25717C17.5954 7.09925 17.3812 7.01053 17.1579 7.01053H15.4737C15.2503 7.01053 15.0362 7.09925 14.8782 7.25717Z" />
@@ -249,7 +261,8 @@ export const IconBadgeCheckSolid: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 20 20"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Badge Check'}</title>
       <path
         fillRule="evenodd"
@@ -271,7 +284,8 @@ export const IconBadgeCheck: FC<IconProps> = ({
       className={className}
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Badge Check'}</title>
       <path
         strokeLinecap="round"
@@ -293,7 +307,8 @@ export const IconLockClosed: FC<IconProps> = ({
       className={className}
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Lock Closed'}</title>
       <path
         strokeLinecap="round"
@@ -312,7 +327,8 @@ export const IconMinus: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth="2">
+      strokeWidth="2"
+    >
       <title>{title ? title : 'Minus'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M18 12H6" />
     </svg>
@@ -330,7 +346,8 @@ export const IconAnnotation: FC<IconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Annotation'}</title>
       <path
         strokeLinecap="round"
@@ -353,7 +370,8 @@ export const IconThumbUp: FC<IconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Like'}</title>
       <path
         strokeLinecap="round"
@@ -385,7 +403,8 @@ export const IconPaperAirplane: FC<IconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Send'}</title>
       <path
         strokeLinecap="round"
@@ -402,7 +421,8 @@ export const IconPaperAirplaneSolid: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className}`}>
+      className={`${className}`}
+    >
       <title>{title ? title : 'Send'}</title>
       <path d="M3.478 2.405a.75.75 0 00-.926.94l2.432 7.905H13.5a.75.75 0 010 1.5H4.984l-2.432 7.905a.75.75 0 00.926.94 60.519 60.519 0 0018.445-8.986.75.75 0 000-1.218A60.517 60.517 0 003.478 2.405z" />
     </svg>
@@ -417,7 +437,8 @@ export const IconSelector: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth="2">
+      strokeWidth="2"
+    >
       <title>{title ? title : 'Selector'}</title>
       <path
         strokeLinecap="round"
@@ -436,7 +457,8 @@ export const IconCheck: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       stroke="currentColor"
-      strokeWidth="2">
+      strokeWidth="2"
+    >
       <title>{title ? title : 'Check'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
     </svg>
@@ -454,7 +476,8 @@ export const IconCheckBadge: FC<IconProps> = ({
       className={className}
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Check Badge'}</title>
       <path
         strokeLinecap="round"
@@ -489,7 +512,8 @@ export const IconSearch: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={strokeWidth ?? 2}>
+      strokeWidth={strokeWidth ?? 2}
+    >
       <title>{title ? title : 'Search'}</title>
       <path
         strokeLinecap="round"
@@ -509,7 +533,8 @@ export const IconFilter: FC<IconProps> = ({ className, title }) => {
       strokeLinecap="round"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className}`}>
+      className={`${className}`}
+    >
       <title>{title ? title : 'Filter'}</title>
       <line x1="9.75" y1="16.25" x2="14.25" y2="16.25" />
       <line x1="5.75" y1="11.25" x2="18.25" y2="11.25" />
@@ -524,7 +549,8 @@ export const IconGrid: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 20 20"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className}`}>
+      className={`${className}`}
+    >
       <title>{title ? title : 'Grid'}</title>
       <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
     </svg>
@@ -537,7 +563,8 @@ export const IconList: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 20 20"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className}`}>
+      className={`${className}`}
+    >
       <title>{title ? title : 'List'}</title>
       <path
         fillRule="evenodd"
@@ -556,7 +583,8 @@ export const IconGroup: FC<IconProps> = ({ className, title, strokeWidth }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Group'}</title>
       <path
         strokeLinecap="round"
@@ -579,7 +607,8 @@ export const IconGroupPlus: FC<IconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       className={`${className}`}
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Add Group'}</title>
       <path
         strokeLinecap="round"
@@ -602,7 +631,8 @@ export const IconEllipsisVertical: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Options'}</title>
       <path
         d="M11.75 6.5C11.5511 6.5 11.3603 6.42098 11.2197 6.28033C11.079 6.13968 11 5.94891 11 5.75C11 5.55109 11.079 5.36032 11.2197 5.21967C11.3603 5.07902 11.5511 5 11.75 5C11.9489 5 12.1397 5.07902 12.2803 5.21967C12.421 5.36032 12.5 5.55109 12.5 5.75C12.5 5.94891 12.421 6.13968 12.2803 6.28033C12.1397 6.42098 11.9489 6.5 11.75 6.5ZM11.75 12.5C11.5511 12.5 11.3603 12.421 11.2197 12.2803C11.079 12.1397 11 11.9489 11 11.75C11 11.5511 11.079 11.3603 11.2197 11.2197C11.3603 11.079 11.5511 11 11.75 11C11.9489 11 12.1397 11.079 12.2803 11.2197C12.421 11.3603 12.5 11.5511 12.5 11.75C12.5 11.9489 12.421 12.1397 12.2803 12.2803C12.1397 12.421 11.9489 12.5 11.75 12.5ZM11.75 18.5C11.5511 18.5 11.3603 18.421 11.2197 18.2803C11.079 18.1397 11 17.9489 11 17.75C11 17.5511 11.079 17.3603 11.2197 17.2197C11.3603 17.079 11.5511 17 11.75 17C11.9489 17 12.1397 17.079 12.2803 17.2197C12.421 17.3603 12.5 17.5511 12.5 17.75C12.5 17.9489 12.421 18.1397 12.2803 18.2803C12.1397 18.421 11.9489 18.5 11.75 18.5Z"
@@ -625,7 +655,8 @@ export const IconEllipsisHorizontal: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Options'}</title>
       <path
         strokeLinecap="round"
@@ -644,7 +675,8 @@ export const IconTrash: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Trash'}</title>
       <path
         strokeLinecap="round"
@@ -667,7 +699,8 @@ export const IconCustomList: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'List'}</title>
       <rect x="14" y="10" width="7" height="7" />
       <line x1="2" y1="16" x2="11" y2="16" />
@@ -685,7 +718,8 @@ export const IconCash: FC<IconProps> = ({ className, title }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={1.5}>
+      strokeWidth={1.5}
+    >
       <title>{title ? title : 'Cash'}</title>
       <path
         strokeLinecap="round"
@@ -708,7 +742,8 @@ export const IconDocumentDownload: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Document Download'}</title>
       <path
         strokeLinecap="round"
@@ -731,7 +766,8 @@ export const IconDocument: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Document'}</title>
       <path
         strokeLinecap="round"
@@ -754,7 +790,8 @@ export const IconDocumentText: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Document Text'}</title>
       <path
         strokeLinecap="round"
@@ -777,7 +814,8 @@ export const IconNewspaper: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'News'}</title>
       <path
         strokeLinecap="round"
@@ -800,7 +838,8 @@ export const IconPlayCircle: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Play Circle'}</title>
       <path
         strokeLinecap="round"
@@ -824,7 +863,8 @@ export const IconUsers: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Users'}</title>
       <path
         strokeLinecap="round"
@@ -843,7 +883,8 @@ export const IconUser: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'User'}</title>
       <path
         strokeLinecap="round"
@@ -861,7 +902,8 @@ export const IconUserSolid: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
       stroke="none"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'User'}</title>
       <path
         fillRule="evenodd"
@@ -879,7 +921,8 @@ export const IconUserPlaceholder: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
       stroke="none"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'User'}</title>
       <rect opacity="0.20" width="24" height="24" rx="12" />
       <path d="M19 21.7479C17.0298 23.1652 14.6124 24 12 24C9.38763 24 6.97024 23.1652 5 21.7479V20.6C5 18.0595 7.05949 16 9.6 16H14.4C16.9405 16 19 18.0595 19 20.6V21.7479Z" />
@@ -895,7 +938,8 @@ export const IconCompanyPlaceholder: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
       stroke="none"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'Company'}</title>
       <rect opacity="0.20" width="24" height="24" />
       <path
@@ -919,7 +963,8 @@ export const IconExclamationTriangle: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Warning'}</title>
       <path
         strokeLinecap="round"
@@ -942,7 +987,8 @@ export const IconUserPlus: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Add User'}</title>
       <path
         strokeLinecap="round"
@@ -965,7 +1011,8 @@ export const IconUserCircle: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'User'}</title>
       <path
         strokeLinecap="round"
@@ -982,7 +1029,8 @@ export const IconUserCircleSolid: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'User'}</title>
       <path
         fillRule="evenodd"
@@ -1001,7 +1049,8 @@ export const IconAlert: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Alert'}</title>
       <path
         strokeLinecap="round"
@@ -1018,7 +1067,8 @@ export const IconAlertSolid: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'Alert'}</title>
       <path d="M5.85 3.5a.75.75 0 00-1.117-1 9.719 9.719 0 00-2.348 4.876.75.75 0 001.479.248A8.219 8.219 0 015.85 3.5zM19.267 2.5a.75.75 0 10-1.118 1 8.22 8.22 0 011.987 4.124.75.75 0 001.48-.248A9.72 9.72 0 0019.266 2.5z" />
       <path
@@ -1036,7 +1086,8 @@ export const IconImage: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      fill="currentColor">
+      fill="currentColor"
+    >
       <title>{title ? title : 'Image'}</title>
       <path
         fillRule="evenodd"
@@ -1055,7 +1106,8 @@ export const IconFlag: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Flag'}</title>
       <path
         strokeLinecap="round"
@@ -1074,7 +1126,8 @@ export const IconLink: FC<IconProps> = ({ className, title }) => {
       fill="none"
       strokeWidth={1.5}
       stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Link'}</title>
       <path
         strokeLinecap="round"
@@ -1097,7 +1150,8 @@ export const IconExternalLink: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'External Link'}</title>
       <path
         strokeLinecap="round"
@@ -1116,7 +1170,8 @@ export const IconChatBubble: FC<IconProps> = ({ className, title }) => {
       fill="none"
       strokeWidth={1.5}
       stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'SMS'}</title>
       <path
         strokeLinecap="round"
@@ -1133,7 +1188,8 @@ export const IconTelegram: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Telegram'}</title>
       <path
         fillRule="evenodd"
@@ -1153,7 +1209,8 @@ export const IconTelegramAlt: FC<IconProps> = ({ className, title }) => {
       strokeWidth={1.5}
       stroke="currentColor"
       strokeLinejoin="round"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Telegram'}</title>
       <path d="M8 14L3.09674 11.957C2.68806 11.7867 2.68601 11.2084 3.09348 11.0353L21.1443 3.36369C21.511 3.20784 21.9037 3.52258 21.8316 3.91444L18.6584 21.1401C18.5883 21.5204 18.1315 21.6806 17.8392 21.4273L13 17.2333M8 14L19 6.5L11 15.5M8 14L10 20.5M11 15.5L10 20.5M11 15.5L13 17.2333M10 20.5L13 17.2333" />
     </svg>
@@ -1166,7 +1223,8 @@ export const IconWhatsApp: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'WhatsApp'}</title>
       <path
         fillRule="evenodd"
@@ -1183,7 +1241,8 @@ export const IconLinkedIn: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'LinkedIn'}</title>
       <path d="M19.619 2H4.38095C3.06667 2 2 3.06667 2 4.38095V19.619C2 20.9333 3.06667 22 4.38095 22H19.619C20.9333 22 22 20.9333 22 19.619V4.38095C22 3.06667 20.9333 2 19.619 2ZM8.19048 9.61905V18.6667H5.33333V9.61905H8.19048ZM5.33333 6.98571C5.33333 6.31905 5.90476 5.80952 6.7619 5.80952C7.61905 5.80952 8.15714 6.31905 8.19048 6.98571C8.19048 7.65238 7.65714 8.19048 6.7619 8.19048C5.90476 8.19048 5.33333 7.65238 5.33333 6.98571ZM18.6667 18.6667H15.8095C15.8095 18.6667 15.8095 14.2571 15.8095 13.9048C15.8095 12.9524 15.3333 12 14.1429 11.981H14.1048C12.9524 11.981 12.4762 12.9619 12.4762 13.9048C12.4762 14.3381 12.4762 18.6667 12.4762 18.6667H9.61905V9.61905H12.4762V10.8381C12.4762 10.8381 13.3952 9.61905 15.2429 9.61905C17.1333 9.61905 18.6667 10.919 18.6667 13.5524V18.6667Z" />
     </svg>
@@ -1196,7 +1255,8 @@ export const IconLinkedInAlt: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'LinkedIn'}</title>
       <path
         fillRule="evenodd"
@@ -1213,7 +1273,8 @@ export const IconGithub: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Github'}</title>
       <path
         fillRule="evenodd"
@@ -1230,7 +1291,8 @@ export const IconDiscord: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Discord'}</title>
       <path
         fillRule="evenodd"
@@ -1247,7 +1309,8 @@ export const IconGlassdoor: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="none"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Glassdoor'}</title>
       <path
         fillRule="evenodd"
@@ -1265,7 +1328,8 @@ export const IconTwitter: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Twitter'}</title>
       <path d="M8.29 20.2534C15.837 20.2534 19.965 14.0004 19.965 8.5784C19.965 8.4004 19.965 8.2234 19.953 8.0484C20.7562 7.46693 21.4493 6.74701 22 5.9224C21.2511 6.2544 20.4566 6.47216 19.643 6.5684C20.4996 6.05546 21.1408 5.24875 21.447 4.2984C20.6417 4.77628 19.7607 5.11313 18.842 5.2944C18.2234 4.63616 17.405 4.20023 16.5136 4.0541C15.6222 3.90797 14.7075 4.0598 13.9111 4.48607C13.1147 4.91234 12.4811 5.58927 12.1083 6.41206C11.7355 7.23485 11.6444 8.15758 11.849 9.0374C10.2176 8.95564 8.6216 8.53172 7.16465 7.79317C5.70769 7.05461 4.42233 6.01792 3.392 4.7504C2.86732 5.6536 2.70659 6.72282 2.94254 7.74036C3.17848 8.75791 3.79337 9.64728 4.662 10.2274C4.00926 10.2085 3.37065 10.0329 2.8 9.7154V9.7674C2.80039 10.7147 3.1284 11.6327 3.7284 12.3658C4.3284 13.0988 5.16347 13.6018 6.092 13.7894C5.48781 13.9541 4.85389 13.9781 4.239 13.8594C4.50116 14.6749 5.01168 15.388 5.69913 15.899C6.38658 16.41 7.21657 16.6934 8.073 16.7094C7.22212 17.378 6.24779 17.8722 5.20573 18.1639C4.16367 18.4556 3.07432 18.539 2 18.4094C3.8766 19.6137 6.06019 20.2525 8.29 20.2494" />
     </svg>
@@ -1278,12 +1342,14 @@ export const IconInstagram: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Instagram'}</title>
       <path
         fillRule="evenodd"
         d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z"
-        clipRule="evenodd"></path>
+        clipRule="evenodd"
+      ></path>
     </svg>
   );
 };
@@ -1294,12 +1360,14 @@ export const IconFacebook: FC<IconProps> = ({ className, title }) => {
       className={className}
       fill="currentColor"
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Facebook'}</title>
       <path
         fillRule="evenodd"
         d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
-        clipRule="evenodd"></path>
+        clipRule="evenodd"
+      ></path>
     </svg>
   );
 };
@@ -1318,7 +1386,8 @@ export const IconTicket: FC<IconProps> = ({
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       strokeLinecap="round"
-      strokeLinejoin="round">
+      strokeLinejoin="round"
+    >
       <title>{title ? title : 'Ticket'}</title>
       <path
         strokeLinecap="round"
@@ -1341,7 +1410,8 @@ export const IconBriefcase: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Briefcase'}</title>
       <path
         strokeLinecap="round"
@@ -1362,7 +1432,8 @@ export const IconRole: FC<IconProps> = ({ className, title, strokeWidth }) => {
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       strokeLinecap="round"
-      strokeLinejoin="round">
+      strokeLinejoin="round"
+    >
       <title>{title ? title : 'Role'}</title>
       <path d="M9.58333 6.25H4.16667C3.59203 6.25 3.04093 6.47827 2.6346 6.8846C2.22827 7.29093 2 7.84203 2 8.41667V18.1667C2 18.7413 2.22827 19.2924 2.6346 19.6987C3.04093 20.1051 3.59203 20.3333 4.16667 20.3333H19.3333C19.908 20.3333 20.4591 20.1051 20.8654 19.6987C21.2717 19.2924 21.5 18.7413 21.5 18.1667V8.41667C21.5 7.84203 21.2717 7.29093 20.8654 6.8846C20.4591 6.47827 19.908 6.25 19.3333 6.25H13.9167M9.58333 6.25V5.16667C9.58333 4.59203 9.81161 4.04093 10.2179 3.6346C10.6243 3.22827 11.1754 3 11.75 3C12.3246 3 12.8757 3.22827 13.2821 3.6346C13.6884 4.04093 13.9167 4.59203 13.9167 5.16667V6.25M9.58333 6.25C9.58333 6.82464 9.81161 7.37574 10.2179 7.78206C10.6243 8.18839 11.1754 8.41667 11.75 8.41667C12.3246 8.41667 12.8757 8.18839 13.2821 7.78206C13.6884 7.37574 13.9167 6.82464 13.9167 6.25M8.5 14.9167C9.91483 14.9167 11.1184 15.8213 11.5658 17.0833M8.5 14.9167C7.82766 14.9165 7.17181 15.1247 6.62274 15.5128C6.07368 15.9008 5.65843 16.4495 5.43417 17.0833M15 11.6667H18.25M15 16H17.1667M8.5 14.9167C9.07464 14.9167 9.62574 14.6884 10.0321 14.2821C10.4384 13.8757 10.6667 13.3246 10.6667 12.75C10.6667 12.1754 10.4384 11.6243 10.0321 11.2179C9.62574 10.8116 9.07464 10.5833 8.5 10.5833C7.92536 10.5833 7.37426 10.8116 6.96794 11.2179C6.56161 11.6243 6.33333 12.1754 6.33333 12.75C6.33333 13.3246 6.56161 13.8757 6.96794 14.2821C7.37426 14.6884 7.92536 14.9167 8.5 14.9167Z" />
     </svg>
@@ -1377,7 +1448,8 @@ export const IconGlobe: FC<IconProps> = ({ className, title, strokeWidth }) => {
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Website'}</title>
       <path
         strokeLinecap="round"
@@ -1396,7 +1468,8 @@ export const IconBell: FC<IconProps> = ({ className, title, strokeWidth }) => {
       viewBox="0 0 24 24"
       aria-hidden="true"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Notification'}</title>
       <path
         strokeLinecap="round"
@@ -1415,7 +1488,8 @@ export const IconCopy: FC<IconProps> = ({ className, title, strokeWidth }) => {
       viewBox="0 0 24 24"
       aria-hidden="true"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Copy'}</title>
       <path
         strokeLinecap="round"
@@ -1434,7 +1508,8 @@ export const IconEmail: FC<IconProps> = ({ className, title, strokeWidth }) => {
       viewBox="0 0 24 24"
       aria-hidden="true"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Email'}</title>
       <path
         strokeLinecap="round"
@@ -1457,7 +1532,8 @@ export const IconCompanies: FC<IconProps> = ({
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Companies'}</title>
       <path
         strokeLinecap="round"
@@ -1480,7 +1556,8 @@ export const IconCalendarDays: FC<IconProps> = ({
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Calendar'}</title>
       <path
         strokeLinecap="round"
@@ -1503,7 +1580,8 @@ export const IconCalendarAdd: FC<IconProps> = ({
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Add to Calendar'}</title>
       <path
         d="M6.75 3V5.25M17.25 3V5.25M3 18.75V7.5C3 6.90326 3.23705 6.33097 3.65901 5.90901C4.08097 5.48705 4.65326 5.25 5.25 5.25H18.75C19.3467 5.25 19.919 5.48705 20.341 5.90901C20.7629 6.33097 21 6.90326 21 7.5V18.75M3 18.75C3 19.3467 3.23705 19.919 3.65901 20.341C4.08097 20.7629 4.65326 21 5.25 21H18.75C19.3467 21 19.919 20.7629 20.341 20.341C20.7629 19.919 21 19.3467 21 18.75M3 18.75V11.25C3 10.6533 3.23705 10.081 3.65901 9.65901C4.08097 9.23705 4.65326 9 5.25 9H18.75C19.3467 9 19.919 9.23705 20.341 9.65901C20.7629 10.081 21 10.6533 21 11.25V18.75"
@@ -1531,7 +1609,8 @@ export const IconCalendar: FC<IconProps> = ({
       stroke="currentColor"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       viewBox="0 0 24 24"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <title>{title ? title : 'Add to Calendar'}</title>
       <path
         strokeLinecap="round"
@@ -1549,7 +1628,8 @@ export const IconPlus: FC<IconProps> = ({ className, title, strokeWidth }) => {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Plus'}</title>
       <path
         strokeLinecap="round"
@@ -1571,7 +1651,8 @@ export const IconPlusSmall: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Add'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m6-6H6" />
     </svg>
@@ -1590,7 +1671,8 @@ export const IconChevronLeft: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Left'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
     </svg>
@@ -1609,7 +1691,8 @@ export const IconChevronRight: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Right'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
     </svg>
@@ -1624,7 +1707,8 @@ export const IconChevronDown: FC<IconProps> = ({ className, title }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={2}>
+      strokeWidth={2}
+    >
       <title>{title ? title : 'Down'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
     </svg>
@@ -1637,7 +1721,8 @@ export const IconChevronDownMini: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
-      fill="currentColor">
+      fill="currentColor"
+    >
       <title>{title ? title : 'Down'}</title>
       <path
         fillRule="evenodd"
@@ -1654,7 +1739,8 @@ export const IconPolygonDown: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      fill="currentColor">
+      fill="currentColor"
+    >
       <title>{title ? title : 'Down'}</title>
       <path d="M11.4816 16.0643C11.7594 16.3705 12.2406 16.3705 12.5184 16.0643L17.0004 11.1243C17.4085 10.6745 17.0893 9.95392 16.4819 9.95392H7.51807C6.9107 9.95392 6.59153 10.6745 6.99964 11.1243L11.4816 16.0643Z" />
     </svg>
@@ -1673,7 +1759,8 @@ export const IconChevronUp: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Down'}</title>
       <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
     </svg>
@@ -1688,7 +1775,8 @@ export const IconHome: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 1.5}>
+      strokeWidth={strokeWidth ? strokeWidth : 1.5}
+    >
       <title>{title ? title : 'Home'}</title>
       <path
         strokeLinecap="round"
@@ -1705,7 +1793,8 @@ export const IconDashboard: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 24 24"
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Dashboard'}</title>
       <path
         fillRule="evenodd"
@@ -1728,7 +1817,8 @@ export const IconSettings: FC<IconProps> = ({
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Settings'}</title>
       <path
         strokeLinecap="round"
@@ -1756,7 +1846,8 @@ export const IconOrganization: FC<IconProps> = ({
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Settings'}</title>
       <path
         strokeLinecap="round"
@@ -1779,7 +1870,8 @@ export const IconSignOut: FC<IconProps> = ({
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Sign out'}</title>
       <path
         strokeLinecap="round"
@@ -1798,7 +1890,8 @@ export const IconX: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 2}>
+      strokeWidth={strokeWidth ? strokeWidth : 2}
+    >
       <title>{title ? title : 'Close'}</title>
       <path
         strokeLinecap="round"
@@ -1817,7 +1910,8 @@ export const IconBars3: FC<IconProps> = ({ className, title, strokeWidth }) => {
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      strokeWidth={strokeWidth ? strokeWidth : 2}>
+      strokeWidth={strokeWidth ? strokeWidth : 2}
+    >
       <title>{title ? title : 'Close'}</title>
       <path
         strokeLinecap="round"
@@ -1840,7 +1934,8 @@ export const IconLocation: FC<IconProps> = ({
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Location'}</title>
       <path
         strokeLinecap="round"
@@ -1864,7 +1959,8 @@ export const IconEditPencilOLD: FC<IconProps> = ({ className, title }) => {
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={2}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Edit'}</title>
       <path
         strokeLinecap="round"
@@ -1887,7 +1983,8 @@ export const IconEditPencil: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Edit'}</title>
       <path
         d="M13.6765 5.62489L16.0706 3.22978C16.7928 2.50756 17.41 1.9173 19.4297 3.93689C21.4493 5.95648 20.859 6.57377 20.1368 7.296L7.8891 19.5437C7.36043 20.072 6.70847 20.4604 5.99211 20.6737L2.6 20.7666L2.69289 17.3745C2.90617 16.6581 3.29453 16.0061 3.82289 15.4775L13.6775 5.62489H13.6765ZM13.6765 5.62489L17.7287 9.6771"
@@ -1910,7 +2007,8 @@ export const IconPencilSquare: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Edit'}</title>
       <path
         strokeLinecap="round"
@@ -1927,7 +2025,8 @@ export const IconSortDown: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       viewBox="0 0 24 24"
-      fill="currentColor">
+      fill="currentColor"
+    >
       <title>{title ? title : 'Sort'}</title>
       <path
         fillRule="evenodd"
@@ -1944,7 +2043,8 @@ export const IconSortUp: FC<IconProps> = ({ className, title }) => {
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       viewBox="0 0 24 24"
-      fill="currentColor">
+      fill="currentColor"
+    >
       <title>{title ? title : 'Sort'}</title>
       <path
         fillRule="evenodd"
@@ -1962,7 +2062,8 @@ export const IconSave: FC<IconProps> = ({ className, title }) => {
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
-      viewBox="0 0 24 24">
+      viewBox="0 0 24 24"
+    >
       <title>{title ? title : 'Save'}</title>
       <path
         d="M20.4258 6.5H16.4258V10.5H14.4258V6.5H10.4258V4.5H14.4258V0.5H16.4258V4.5H20.4258V6.5ZM12.4258 0.5H0.425781V1.5H12.4258V0.5ZM0.425781 5.5H8.42578V4.5H0.425781V5.5ZM0.425781 9.5H8.42578V8.5H0.425781V9.5Z"
@@ -1984,7 +2085,8 @@ export const IconListPlus: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Save To List'}</title>
       <path d="M17.9255 8V17M13.4255 12.5H22.4255" />
       <line x1="2.42554" y1="16" x2="11.4255" y2="16" />
@@ -2006,7 +2108,8 @@ export const IconListSaved: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Save To List'}</title>
       <path d="M13.2,13.9l3.1,2.5L21,10" />
       <line x1="2.42554" y1="16" x2="11.4255" y2="16" />
@@ -2028,7 +2131,8 @@ export const IconColumns: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'columns'}</title>
       <path
         strokeLinecap="round"
@@ -2047,7 +2151,8 @@ export const IconTable: FC<IconProps> = ({ className, strokeWidth, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Table'}</title>
       <path
         strokeLinecap="round"
@@ -2065,7 +2170,8 @@ export const IconShare: FC<IconProps> = ({ className, strokeWidth, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Share'}</title>
       <path
         strokeLinecap="round"
@@ -2088,7 +2194,8 @@ export const IconShareAlt: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Share'}</title>
       <path
         strokeLinecap="round"
@@ -2111,7 +2218,8 @@ export const IconShare3: FC<IconProps> = ({
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Share'}</title>
       <path
         fillRule="evenodd"
@@ -2135,7 +2243,8 @@ export const IconFindCompanies: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 2}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Find Companies'}</title>
       <path
         d="M19 21V5C19 4.46957 18.7893 3.96086 18.4142 3.58579C18.0391 3.21071 17.5304 3 17 3H7C6.46957 3 5.96086 3.21071 5.58579 3.58579C5.21071 3.96086 5 4.46957 5 5V21M19 21H5M19 21H21M19 21H14M5 21H3M5 21H10M14 21V16C14 15.7348 13.8946 15.4804 13.7071 15.2929C13.5196 15.1054 13.2652 15 13 15H11C10.7348 15 10.4804 15.1054 10.2929 15.2929C10.1054 15.4804 10 15.7348 10 16V21M14 21H10M9 7H10M9 11H10M14 7H15M14 11H15"
@@ -2152,7 +2261,8 @@ export const IconFindInvestors: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Find Investors'}</title>
       <path d="M6 19V20V19ZM18 19V20V19ZM21 16H22H21ZM21 8H22H21ZM3 8H2H3ZM3 16H2H3ZM13 15.75C13 15.1977 12.5523 14.75 12 14.75C11.4477 14.75 11 15.1977 11 15.75H13ZM11 16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16H11ZM12.5 11.9998L12.7425 11.0296L12.7194 11.0239L12.6961 11.0192L12.5 11.9998ZM13 7.75C13 7.19772 12.5523 6.75 12 6.75C11.4477 6.75 11 7.19772 11 7.75H13ZM11 8C11 8.55228 11.4477 9 12 9C12.5523 9 13 8.55228 13 8H11ZM6 20H18V18H6V20ZM18 20C19.0609 20 20.0783 19.5786 20.8284 18.8284L19.4142 17.4142C19.0391 17.7893 18.5304 18 18 18V20ZM20.8284 18.8284C21.5786 18.0783 22 17.0609 22 16H20C20 16.5304 19.7893 17.0391 19.4142 17.4142L20.8284 18.8284ZM22 16V8H20V16H22ZM22 8C22 6.93913 21.5786 5.92172 20.8284 5.17157L19.4142 6.58579C19.7893 6.96086 20 7.46957 20 8H22ZM20.8284 5.17157C20.0783 4.42143 19.0609 4 18 4V6C18.5304 6 19.0391 6.21071 19.4142 6.58579L20.8284 5.17157ZM18 4H6V6H18V4ZM6 4C4.93913 4 3.92172 4.42143 3.17157 5.17157L4.58579 6.58579C4.96086 6.21071 5.46957 6 6 6V4ZM3.17157 5.17157C2.42143 5.92172 2 6.93913 2 8H4C4 7.46957 4.21071 6.96086 4.58579 6.58579L3.17157 5.17157ZM2 8V16H4V8H2ZM2 16C2 17.0609 2.42143 18.0783 3.17157 18.8284L4.58579 17.4142C4.21071 17.0391 4 16.5304 4 16H2ZM3.17157 18.8284C3.92172 19.5786 4.93913 20 6 20V18C5.46957 18 4.96086 17.7893 4.58579 17.4142L3.17157 18.8284ZM11 15.75V16H13V15.75H11ZM12.2575 12.97C13.0809 13.1757 13.3041 13.4994 13.3499 13.6099C13.3833 13.6902 13.3937 13.8167 13.2304 13.9801C12.9215 14.2889 11.6553 14.7982 9.61394 13.2104L8.38606 14.7892C10.8447 16.7014 13.3285 16.7105 14.6446 15.3943C15.2938 14.7451 15.5854 13.7779 15.1969 12.8426C14.8209 11.9375 13.9191 11.3237 12.7425 11.0296L12.2575 12.97ZM15.5548 8.66786C13.0967 7.02887 10.5557 7.1624 9.40115 8.63191C8.79577 9.40247 8.71799 10.4425 9.3222 11.3288C9.88137 12.1489 10.9259 12.7048 12.3039 12.9804L12.6961 11.0192C11.5741 10.7949 11.1186 10.4133 10.9747 10.2021C10.8758 10.057 10.8917 9.97201 10.9738 9.86749C11.1943 9.58684 12.4033 8.9703 14.4452 10.3319L15.5548 8.66786ZM11 7.75V8H13V7.75H11Z" />
     </svg>
@@ -2165,7 +2275,8 @@ export const IconFollowing: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Following'}</title>
       <path
         d="M9 12.75L11.25 15L15 9.75M21 12C21 13.1819 20.7672 14.3522 20.3149 15.4442C19.8626 16.5361 19.1997 17.5282 18.364 18.364C17.5282 19.1997 16.5361 19.8626 15.4442 20.3149C14.3522 20.7672 13.1819 21 12 21C10.8181 21 9.64778 20.7672 8.55585 20.3149C7.46392 19.8626 6.47177 19.1997 5.63604 18.364C4.80031 17.5282 4.13738 16.5361 3.68508 15.4442C3.23279 14.3522 3 13.1819 3 12C3 9.61305 3.94821 7.32387 5.63604 5.63604C7.32387 3.94821 9.61305 3 12 3C14.3869 3 16.6761 3.94821 18.364 5.63604C20.0518 7.32387 21 9.61305 21 12Z"
@@ -2184,7 +2295,8 @@ export const IconAcquired: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Acquired'}</title>
       <path
         d="M21 7.42105H21.75V6.67105H21V7.42105ZM21 13.1053L21.206 13.8264L21.75 13.671V13.1053H21ZM7.26316 11.2105L6.79464 10.6249C6.58625 10.7916 6.48214 11.0565 6.52126 11.3205C6.56038 11.5845 6.73683 11.8078 6.98461 11.9069L7.26316 11.2105ZM12.4737 10.2632L13.0737 9.81316C12.9503 9.64869 12.7649 9.54207 12.5607 9.51822C12.3565 9.49437 12.1515 9.55538 11.9935 9.68699L12.4737 10.2632ZM10.5789 19.2632L10.1814 18.6272L10.1814 18.6272L10.5789 19.2632ZM4.42105 13.5789L4.9905 13.0909L4.92316 13.0123L4.83708 12.9549L4.42105 13.5789ZM3 12.6316H2.25V13.033L2.58397 13.2556L3 12.6316ZM3 7.42105L3.10607 6.67859L2.25 6.5563V7.42105H3ZM7.73684 6.47368L7.40143 5.80286L7.29257 5.85729L7.20651 5.94335L7.73684 6.47368ZM12 18.3825L12.3929 19.0214L12 18.3825ZM14.1355 17.0893L14.5174 17.7347L14.5174 17.7347L14.1355 17.0893ZM20.25 7.42105V13.1053H21.75V7.42105H20.25ZM20.794 12.3841C20.2243 12.5469 19.3049 12.8373 18.3797 13.1847C17.4711 13.5259 16.4928 13.9455 15.8471 14.376L16.6792 15.624C17.1704 15.2966 18.0078 14.9267 18.9071 14.589C19.7898 14.2575 20.6704 13.9794 21.206 13.8264L20.794 12.3841ZM21 6.67105C19.4782 6.67105 18.6325 6.35313 17.7851 6.01417C16.8894 5.65587 15.9446 5.25 14.3684 5.25V6.75C15.6344 6.75 16.3475 7.05465 17.228 7.40688C18.1569 7.77844 19.206 8.17105 21 8.17105V6.67105ZM6.98461 11.9069C7.2648 12.019 8.05459 12.4693 9.08125 12.4932C10.157 12.5182 11.433 12.1067 12.9538 10.8393L11.9935 9.68699C10.6723 10.788 9.73776 11.0081 9.11612 10.9936C8.44541 10.978 8.05099 10.7179 7.5417 10.5142L6.98461 11.9069ZM11.8737 10.7132C13.0155 12.2356 13.3045 12.6207 15.2038 14.9948L16.3751 14.0578C14.4849 11.6951 14.2055 11.3223 13.0737 9.81316L11.8737 10.7132ZM15.2038 14.9948C15.2994 15.1143 15.3539 15.2698 15.3457 15.3786C15.3425 15.4214 15.33 15.4648 15.2932 15.5152C15.2539 15.5691 15.1675 15.6566 14.9804 15.7502L15.6512 17.0919C16.3903 16.7223 16.792 16.1481 16.8415 15.4912C16.886 14.8992 16.6326 14.3797 16.3751 14.0578L15.2038 14.9948ZM10.1814 18.6272C10.0316 18.7208 10.0096 18.7135 10.047 18.7075C10.1328 18.6937 10.1976 18.7263 10.1906 18.7221C10.1513 18.6992 10.0679 18.6354 9.88959 18.4625C9.71433 18.2927 9.5127 18.0836 9.21454 17.7855L8.15388 18.8461C8.42414 19.1164 8.66157 19.3612 8.84566 19.5396C9.02665 19.7151 9.2229 19.8939 9.43324 20.0169C9.67575 20.1588 9.96011 20.2407 10.285 20.1885C10.5616 20.144 10.7983 20.0105 10.9764 19.8992L10.1814 18.6272ZM9.21454 17.7855C8.10149 16.6724 5.94109 14.1999 4.9905 13.0909L3.85161 14.067C4.79576 15.1685 6.99325 17.6855 8.15388 18.8461L9.21454 17.7855ZM4.83708 12.9549L3.41603 12.0075L2.58397 13.2556L4.00503 14.203L4.83708 12.9549ZM3.75 12.6316V7.42105H2.25V12.6316H3.75ZM2.89393 8.16351C3.50237 8.25043 4.47048 8.3011 5.4508 8.17695C6.40485 8.05613 7.51939 7.75179 8.26717 7.00401L7.20651 5.94335C6.81745 6.33242 6.11621 6.58071 5.26235 6.68884C4.43478 6.79364 3.6029 6.74957 3.10607 6.67859L2.89393 8.16351ZM14.3684 5.25C13.3742 5.25 12.408 5.73909 11.5591 6.33274L12.4187 7.562C13.1911 7.0219 13.8425 6.75 14.3684 6.75V5.25ZM11.5591 6.33274C10.6457 6.97148 9.74699 7.81944 8.94127 8.60617C8.11203 9.41587 7.40004 10.1405 6.79464 10.6249L7.73168 11.7962C8.41297 11.2511 9.20613 10.444 9.98922 9.6794C10.7958 8.89179 11.6167 8.12285 12.4187 7.562L11.5591 6.33274ZM8.07225 7.1445C8.83116 6.76505 9.58786 6.76107 10.2221 6.90822C10.8811 7.06114 11.3388 7.36074 11.4647 7.48381L12.513 6.41093C12.1542 6.06032 11.4332 5.64939 10.5611 5.44704C9.66419 5.23893 8.53727 5.23495 7.40143 5.80286L8.07225 7.1445ZM11.6071 17.7437C11.0633 18.0781 10.5582 18.3917 10.1814 18.6272L10.9764 19.8992C11.3502 19.6656 11.8522 19.3539 12.3929 19.0214L11.6071 17.7437ZM12.6037 17.9375L9.76163 14.0813L8.55416 14.9713L11.3963 18.8275L12.6037 17.9375ZM14.9804 15.7502C14.716 15.8824 14.2654 16.141 13.7536 16.4438L14.5174 17.7347C15.0362 17.4278 15.4419 17.1965 15.6512 17.0919L14.9804 15.7502ZM13.7536 16.4438C13.1047 16.8277 12.3211 17.3046 11.6071 17.7437L12.3929 19.0214C13.1039 18.5841 13.8793 18.1123 14.5174 17.7347L13.7536 16.4438ZM14.7287 16.6303L11.6458 12.6463L10.4595 13.5643L13.5424 17.5483L14.7287 16.6303Z"
@@ -2206,7 +2318,8 @@ export const IconTrending: FC<IconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Trending'}</title>
       <path
         d="M2.25 18.0001L9 11.2501L13.306 15.5571C14.5507 13.1029 16.6044 11.1535 19.12 10.0381L21.86 8.81809M21.86 8.81809L15.92 6.53809M21.86 8.81809L19.58 14.7591"
@@ -2231,7 +2344,8 @@ export const IconSparkles: FC<IconProps> = ({
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Sparkles'}</title>
       <path
         strokeLinecap="round"
@@ -2254,7 +2368,8 @@ export const IconContributor: FC<IconProps> = ({
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
       stroke="currentColor"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Contributor'}</title>
       <path
         strokeLinecap="round"
@@ -2284,7 +2399,8 @@ export const IconDead: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}>
+      className={className}
+    >
       <title>{title ? title : 'Dead'}</title>
       <mask
         id="path-1-outside-1_5067_11599"
@@ -2293,7 +2409,8 @@ export const IconDead: FC<IconProps> = ({ className, title }) => {
         y="1.71924"
         width="18"
         height="21"
-        fill="black">
+        fill="black"
+      >
         <rect fill="white" x="2.69519" y="1.71924" width="18" height="21" />
         <path
           fillRule="evenodd"
@@ -2354,7 +2471,8 @@ export const IconHide: FC<IconProps> = ({ className, strokeWidth, title }) => {
       fill="none"
       viewBox="0 0 32 32"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Hide'}</title>
       <path d="M16,9.5c-3.443,0 -6.493,1.022 -8.386,2.57c-1.342,1.099 -2.114,2.465 -2.114,3.93c0,1.465 0.772,2.831 2.114,3.93c1.893,1.548 4.943,2.57 8.386,2.57c3.443,0 6.493,-1.022 8.386,-2.57c1.342,-1.099 2.114,-2.465 2.114,-3.93c0,-1.465 -0.772,-2.831 -2.114,-3.93c-1.893,-1.548 -4.943,-2.57 -8.386,-2.57Zm0,1c3.18,0 6.005,0.914 7.753,2.344c1.085,0.888 1.747,1.972 1.747,3.156c0,1.184 -0.662,2.268 -1.747,3.156c-1.748,1.43 -4.573,2.344 -7.753,2.344c-3.18,0 -6.005,-0.914 -7.753,-2.344c-1.085,-0.888 -1.747,-1.972 -1.747,-3.156c0,-1.184 0.662,-2.268 1.747,-3.156c1.748,-1.43 4.573,-2.344 7.753,-2.344Z" />
       <path d="M16,12.78c-1.777,0 -3.22,1.443 -3.22,3.22c0,1.777 1.443,3.22 3.22,3.22c1.777,-0 3.22,-1.443 3.22,-3.22c-0,-1.777 -1.443,-3.22 -3.22,-3.22Zm0,1c1.225,0 2.22,0.995 2.22,2.22c-0,1.225 -0.995,2.22 -2.22,2.22c-1.225,-0 -2.22,-0.995 -2.22,-2.22c0,-1.225 0.995,-2.22 2.22,-2.22Z" />
@@ -2369,7 +2487,8 @@ export const IconApple: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       className={className}
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Apple'}</title>
       <path d="M12.2725 7.74663C11.4825 7.74663 10.26 6.8483 8.97248 6.87997C7.27249 6.90247 5.71417 7.86579 4.83834 9.39162C3.07418 12.4541 4.38334 16.9774 6.10416 19.4665C6.94832 20.6782 7.94415 22.0415 9.26414 21.999C10.5308 21.9449 11.0058 21.1765 12.5433 21.1765C14.0691 21.1765 14.5016 21.999 15.8433 21.9665C17.2074 21.9449 18.0732 20.7332 18.9066 19.5099C19.8699 18.1032 20.2699 16.7391 20.2916 16.6641C20.2591 16.6532 17.6399 15.6466 17.6083 12.6166C17.5866 10.0833 19.6749 8.87162 19.7724 8.81745C18.5816 7.0758 16.7533 6.8808 16.1141 6.83747C14.4474 6.70747 13.0516 7.74663 12.2725 7.74663ZM15.0874 5.19164C15.7899 4.34832 16.2541 3.16916 16.1249 2C15.1191 2.04333 13.9066 2.67083 13.1816 3.51499C12.5316 4.26165 11.97 5.46331 12.1208 6.60997C13.2358 6.69663 14.3833 6.03664 15.0866 5.19248" />
     </svg>
@@ -2382,7 +2501,8 @@ export const IconAppleCalendar: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       className={className}
       fill="none"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Apple Calendar'}</title>
 
       <g filter="url(#filter0_dd_6767_24082)">
@@ -2410,7 +2530,8 @@ export const IconAppleCalendar: FC<IconProps> = ({ className, title }) => {
           x2="12.001"
           y1="8.5"
           y2="22"
-          gradientUnits="userSpaceOnUse">
+          gradientUnits="userSpaceOnUse"
+        >
           <stop stopColor="#FCFCFB" />
           <stop offset="1" stopColor="#F1EFEC" />
         </linearGradient>
@@ -2421,7 +2542,8 @@ export const IconAppleCalendar: FC<IconProps> = ({ className, title }) => {
           x="1.5"
           y="1.8"
           colorInterpolationFilters="sRGB"
-          filterUnits="userSpaceOnUse">
+          filterUnits="userSpaceOnUse"
+        >
           <feFlood floodOpacity="0" result="BackgroundImageFix" />
           <feColorMatrix
             in="SourceAlpha"
@@ -2465,7 +2587,8 @@ export const IconGoogleCalendar: FC<IconProps> = ({ className, title }) => {
       viewBox="0 0 24 24"
       className={className}
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <title>{title ? title : 'Google Calendar'}</title>
       <path
         fill="#fff"
@@ -2508,7 +2631,8 @@ export const IconMicrosoftOutlook: FC<IconProps> = ({ className }) => {
     <svg
       className={className}
       viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg">
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
         d="M22.0001 12.7675C22.0012 12.6111 21.9204 12.4656 21.7871 12.3838H21.7847L21.7764 12.3791L14.8461 8.2768C14.8162 8.25658 14.7851 8.2381 14.7531 8.22146C14.4855 8.08341 14.1677 8.08341 13.9001 8.22146C13.868 8.23811 13.837 8.25658 13.8071 8.2768L6.87683 12.3791L6.86847 12.3838C6.65666 12.5155 6.59172 12.794 6.72344 13.0058C6.76225 13.0682 6.8157 13.1202 6.87916 13.1573L13.8094 17.2596C13.8394 17.2796 13.8705 17.2981 13.9024 17.315C14.17 17.453 14.4879 17.453 14.7555 17.315C14.7874 17.2981 14.8184 17.2796 14.8485 17.2596L21.7787 13.1573C21.9172 13.0766 22.0017 12.9278 22.0001 12.7675Z"
         fill="#0A2767"
@@ -2607,7 +2731,8 @@ export const IconMicrosoftOutlook: FC<IconProps> = ({ className }) => {
           y1="12.7675"
           x2="14.3255"
           y2="21.6047"
-          gradientUnits="userSpaceOnUse">
+          gradientUnits="userSpaceOnUse"
+        >
           <stop stopColor="#35B8F1" />
           <stop offset="1" stopColor="#28A8EA" />
         </linearGradient>
@@ -2617,7 +2742,8 @@ export const IconMicrosoftOutlook: FC<IconProps> = ({ className }) => {
           y1="6.51986"
           x2="10.455"
           y2="18.0848"
-          gradientUnits="userSpaceOnUse">
+          gradientUnits="userSpaceOnUse"
+        >
           <stop stopColor="#1784D9" />
           <stop offset="0.5" stopColor="#107AD5" />
           <stop offset="1" stopColor="#0A63C9" />
@@ -2634,7 +2760,8 @@ export const IconFilterDashboard: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 14 14"
       fill="none"
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Filter'}</title>
       <path
         d="M7 1.75C8.60708 1.75 10.1821 1.88534 11.7151 2.1455C12.026 2.198 12.25 2.46984 12.25 2.78484V3.39383C12.25 3.5662 12.2161 3.73687 12.1501 3.89611C12.0841 4.05535 11.9875 4.20004 11.8656 4.32192L8.69692 7.49058C8.57504 7.61246 8.47836 7.75715 8.4124 7.91639C8.34645 8.07563 8.3125 8.24631 8.3125 8.41867V10.1261C8.31255 10.3699 8.24468 10.6089 8.1165 10.8163C7.98833 11.0237 7.80492 11.1913 7.58683 11.3003L5.6875 12.25V8.41867C5.6875 8.24631 5.65355 8.07563 5.5876 7.91639C5.52164 7.75715 5.42496 7.61246 5.30308 7.49058L2.13442 4.32192C2.01254 4.20004 1.91586 4.05535 1.8499 3.89611C1.78395 3.73687 1.75 3.5662 1.75 3.39383V2.78484C1.75 2.46984 1.974 2.198 2.28492 2.1455C3.84275 1.88175 5.42 1.74945 7 1.75Z"
@@ -2654,7 +2781,8 @@ export const IconSortDashboard: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 14 14"
       fill="none"
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Sort'}</title>
       <path
         d="M1.75 4.375L4.375 1.75M4.375 1.75L7 4.375M4.375 1.75V9.625M12.25 9.625L9.625 12.25M9.625 12.25L7 9.625M9.625 12.25V4.375"
@@ -2674,7 +2802,8 @@ export const IconMarket: FC<IconProps> = ({ className, title }) => {
       className={className}
       viewBox="0 0 14 14"
       fill="none"
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Market'}</title>
       <path
         d="M7.87501 12.25V7.875C7.87501 7.75897 7.92111 7.64769 8.00316 7.56564C8.0852 7.48359 8.19648 7.4375 8.31251 7.4375H10.0625C10.1785 7.4375 10.2898 7.48359 10.3719 7.56564C10.4539 7.64769 10.5 7.75897 10.5 7.875V12.25M7.87501 12.25H1.37668M7.87501 12.25H10.5M10.5 12.25H12.6233M11.8125 12.25V5.45358C12.045 5.31936 12.2435 5.13344 12.3927 4.91022C12.5419 4.68699 12.6376 4.43243 12.6727 4.16625C12.7077 3.90008 12.681 3.62941 12.5947 3.3752C12.5083 3.12098 12.3646 2.89004 12.1748 2.70025L11.4806 2.00667C11.3167 1.84253 11.0943 1.7502 10.8623 1.75H3.13718C2.9052 1.7502 2.68279 1.84253 2.51885 2.00667L1.82526 2.69967C1.63582 2.88968 1.49254 3.12066 1.40647 3.3748C1.3204 3.62894 1.29385 3.89945 1.32885 4.16548C1.36385 4.4315 1.45947 4.68594 1.60834 4.90917C1.75722 5.13239 1.95537 5.31845 2.18751 5.453M2.18751 12.2494V5.45417C2.53753 5.65599 2.94658 5.73053 3.34528 5.66514C3.74399 5.59975 4.1078 5.39846 4.37501 5.09542C4.53911 5.28176 4.74106 5.43096 4.96739 5.53306C5.19372 5.63516 5.43922 5.68781 5.68751 5.6875C6.21018 5.6875 6.67918 5.45825 7.00001 5.09483C7.16405 5.28128 7.36598 5.43059 7.59231 5.5328C7.81864 5.635 8.06418 5.68774 8.31251 5.6875C8.83518 5.6875 9.30418 5.45825 9.62501 5.09483C9.8923 5.39779 10.2562 5.59896 10.6549 5.66424C11.0536 5.72953 11.4626 5.65489 11.8125 5.453M3.93751 10.4994H6.12501C6.24105 10.4994 6.35233 10.4533 6.43437 10.3713C6.51642 10.2892 6.56251 10.1779 6.56251 10.0619V7.875C6.56251 7.75897 6.51642 7.64769 6.43437 7.56564C6.35233 7.48359 6.24105 7.4375 6.12501 7.4375H3.93751C3.82148 7.4375 3.7102 7.48359 3.62816 7.56564C3.54611 7.64769 3.50001 7.75897 3.50001 7.875V10.0625C3.50001 10.3046 3.69601 10.4994 3.93751 10.4994Z"
@@ -2697,7 +2826,8 @@ export const IconSidebarList: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Lists'}</title>
       <path
         strokeLinecap="round"
@@ -2719,7 +2849,8 @@ export const IconSidebarGroups: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Groups'}</title>
       <path
         strokeLinecap="round"
@@ -2741,7 +2872,8 @@ export const IconSidebarNotes: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'Notes'}</title>
       <path
         strokeLinecap="round"
@@ -2763,7 +2895,8 @@ export const IconUserGroup: FC<IconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       strokeWidth={strokeWidth ? strokeWidth : 1.5}
-      stroke="currentColor">
+      stroke="currentColor"
+    >
       <title>{title ? title : 'People'}</title>
       <path
         strokeLinecap="round"

--- a/components/notifications/elem-notification-item.tsx
+++ b/components/notifications/elem-notification-item.tsx
@@ -34,13 +34,14 @@ const ElemNotificationItem: FC<Props> = ({
       <div className="flex items-center space-x-2 sm:pr-20">
         <ElemPhoto
           photo={organization?.logo}
-          wrapClass="flex items-center shrink-0 w-12 h-12 p-1 bg-white rounded border border-slate-200"
+          wrapClass="flex items-center shrink-0 w-12 h-12 bg-white border border-gray-200 rounded-lg overflow-hidden"
           imgClass="object-fit max-w-full max-h-full"
-          imgAlt="Company Name"
-          placeholderClass="text-slate-300"
+          imgAlt={organization?.name}
+          placeholderClass="text-gray-300 p-1"
+          placeholder="company"
         />
         <div className={notification.read ? 'opacity-60' : ''}>
-          <div className="inline text-sm leading-tight text-left lg:text-base">
+          <div className="inline text-sm leading-tight text-left">
             <ElemNotificationMessage
               message={message}
               notification={notification}
@@ -48,7 +49,7 @@ const ElemNotificationItem: FC<Props> = ({
             {extensions.length > 0 && (
               <>
                 {' | '}
-                <span className="leading-tight text-primary-500 hover:border-b hover:border-primary-500">
+                <span className="leading-tight text-primary-500 underline hover:no-underline">
                   Details
                 </span>
                 <IconChevronDownMini className="inline h-5 aspect-square text-primary-500" />
@@ -58,7 +59,7 @@ const ElemNotificationItem: FC<Props> = ({
 
           <div className="text-left">
             <span
-              className={`text-sm  ${
+              className={`text-xs  ${
                 notification.read ? '' : 'font-medium text-primary-500'
               }`}
             >

--- a/components/notifications/elem-notification-message.tsx
+++ b/components/notifications/elem-notification-message.tsx
@@ -25,9 +25,7 @@ const ElemNotificationMessage: FC<Props> = ({ notification, message }) => {
     return (
       <div className="inline">
         <Link href={getNotificationOrganizationLink(notification)} passHref>
-          <a className="border-b border-primary-500 transition-all font-medium">
-            {name}
-          </a>
+          <a className="underline hover:no-underline font-medium">{name}</a>
         </Link>
         <span>{` ${message}`}</span>
       </div>
@@ -40,7 +38,7 @@ const ElemNotificationMessage: FC<Props> = ({ notification, message }) => {
         a: ({ href, children }) => {
           return (
             <Link href={href as string} passHref>
-              <a className="border-b border-primary-500 transition-all font-medium hover:border-b-2 hover:text-primary-500">
+              <a className="underline hover:no-underline font-medium">
                 {children[0]}
               </a>
             </Link>

--- a/components/the-navbar.tsx
+++ b/components/the-navbar.tsx
@@ -134,12 +134,14 @@ export const TheNavbar: FC<Props> = ({}) => {
       <div className="px-1 py-1 sm:px-3 sm:py-2 border-b border-gray-200 bg-white/80 backdrop-blur">
         <nav
           className="flex items-center justify-between lg:justify-start w-full mx-auto"
-          aria-label="Global">
+          aria-label="Global"
+        >
           <div className="flex items-center gap-3">
             <ElemButton
               onClick={() => setShowSidebar(!showSidebar)}
               btn="gray"
-              className="h-9 w-9 !px-0 !py-0 sm:hidden">
+              className="h-9 w-9 !px-0 !py-0 sm:hidden"
+            >
               <IconBars3 className="h-6 w-6" />
             </ElemButton>
 
@@ -163,7 +165,8 @@ export const TheNavbar: FC<Props> = ({}) => {
             <ElemButton
               onClick={() => setShowPopup('search')}
               btn="gray"
-              className="h-9 w-9 !px-0 !py-0 sm:hidden">
+              className="h-9 w-9 !px-0 !py-0 sm:hidden"
+            >
               <IconSearch className="h-5 w-5" />
             </ElemButton>
 
@@ -179,7 +182,8 @@ export const TheNavbar: FC<Props> = ({}) => {
                 enterTo="opacity-100 translate-y-0"
                 leave="transition ease-in duration-150"
                 leaveFrom="opacity-100 translate-y-0"
-                leaveTo="opacity-0 translate-y-1">
+                leaveTo="opacity-0 translate-y-1"
+              >
                 <Popover.Panel className="absolute z-10 mt-2 right-0 w-56 block bg-white rounded-lg border border-gray-300 shadow-lg overflow-hidden">
                   {({ close }) => (
                     <>
@@ -189,7 +193,8 @@ export const TheNavbar: FC<Props> = ({}) => {
                             className="flex items-center gap-x-2 cursor-pointer w-full text-left text-sm px-4 py-2 m-0 transition-all hover:bg-gray-100"
                             onClick={() => {
                               close();
-                            }}>
+                            }}
+                          >
                             {item.label}
                           </a>
                         </Link>


### PR DESCRIPTION
notification alert number cut-off fix:
![Screenshot 2023-09-27 at 4 45 22 PM](https://github.com/5of5/edgein-next/assets/2752967/059b6cff-0f95-4f36-84a4-794459f45369)

consistent sidebar icons stroke width:
![Screenshot 2023-09-27 at 4 45 46 PM](https://github.com/5of5/edgein-next/assets/2752967/7fa09441-fffd-477c-a5d5-335f7fa46a05)

minor notifications style updates to be consistent with other pages on the app:
![Screenshot 2023-09-27 at 4 46 35 PM](https://github.com/5of5/edgein-next/assets/2752967/b9e010a4-e05c-4274-9e0b-0543e9ad6828)
