### PR TITLE
Add missing location_json to vc_firm in data_fields, fixed displaying…

### DIFF
--- a/components/admin/company/company-list.tsx
+++ b/components/admin/company/company-list.tsx
@@ -23,7 +23,7 @@ import { Chip } from '@mui/material';
 import { companyLayerChoices } from '../../../utils/constants';
 import ElemList from '../elem-list';
 import { useAuth } from '@/hooks/use-auth';
-import { getAllTags } from '@/utils/helpers';
+import { getAllTags, getFullAddress } from '@/utils/helpers';
 import { z } from 'zod';
 import { IngestCompaniesReqBody } from '@/pages/api/ingest/companies';
 import axios, { AxiosError } from 'axios';
@@ -245,7 +245,11 @@ export const CompanyList = () => {
       <TextField source="status" />
       <TextField source="aliases" />
       <TextField source="twitter" />
-      <TextField source="location_json" />
+      <FunctionField
+        cellClassName="truncate"
+        source="location_json"
+        render={(record: any) => getFullAddress(record.location_json)}
+      />
       <TextField source="discord" />
       <TextField source="glassdoor" />
       <FunctionField

--- a/components/admin/vcFirm/vc-firm-list.tsx
+++ b/components/admin/vcFirm/vc-firm-list.tsx
@@ -12,6 +12,7 @@ import {
   ChipField,
 } from 'react-admin';
 import ElemList from '../elem-list';
+import { getFullAddress } from '@/utils/helpers';
 
 const filters = [
   <TextInput
@@ -81,7 +82,11 @@ export const VcFirmList = () => {
       />
       <TextField source="year_founded" />
       <TextField source="twitter" />
-      <TextField source="location_json" />
+      <FunctionField
+        cellClassName="truncate"
+        source="location_json"
+        render={(record: any) => getFullAddress(record.location_json)}
+      />
       <FunctionField
         source="library"
         render={(record: any) =>

--- a/infra/hasura/migrations/default/1696858946550_insert_into_public_data_fields/down.sql
+++ b/infra/hasura/migrations/default/1696858946550_insert_into_public_data_fields/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."data_fields" WHERE "path" = 'vc_firm.location_json';

--- a/infra/hasura/migrations/default/1696858946550_insert_into_public_data_fields/up.sql
+++ b/infra/hasura/migrations/default/1696858946550_insert_into_public_data_fields/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."data_fields"("name", "path", "resource", "weight", "regex_transform", "description", "regex_test", "is_valid_identifier", "restricted_admin", "data_type", "created_at") VALUES (E'location_json', E'vc_firm.location_json', E'vc_firm', 1, null, null, null, false, false, null, E'2023-10-09T13:42:26.511676+00:00');


### PR DESCRIPTION
- Proper displaying of `location_json` field in admin panel list (companies, vc_firms)
- Added missing path for `location_json` of `vc_firm` in `data_fields`